### PR TITLE
Url fix

### DIFF
--- a/app/src/main/java/com/example/android/didyoufeelit/MainActivity.java
+++ b/app/src/main/java/com/example/android/didyoufeelit/MainActivity.java
@@ -28,7 +28,7 @@ public class MainActivity extends AppCompatActivity {
 
     /** URL for earthquake data from the USGS dataset */
     private static final String USGS_REQUEST_URL =
-            "http://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&starttime=2016-01-01&endtime=2016-05-02&minfelt=50&minmagnitude=5";
+            "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&starttime=2016-01-01&endtime=2016-05-02&minfelt=50&minmagnitude=5";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
API is giving me error 301 Moved Permanently on Utils.java, line 104. 

Full response is:

> <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN"><html><head><title>301 Moved Permanently</title></head><body><h1>Moved Permanently</h1><p>The document has moved <a href="https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&amp;starttime=2016-01-01&amp;endtime=2016-05-02&amp;minfelt=50&amp;minmagnitude=5">here</a>.</p></body></html>

To fix it, I changed the `USGS_REQUEST_URL` variable to use HTTPS as shown below:

private static final String USGS_REQUEST_URL =
            "https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&starttime=2016-01-01&endtime=2016-05-02&minfelt=50&minmagnitude=5";

Please check other branches and QuakeReport app.